### PR TITLE
Fix null check in updateDocument

### DIFF
--- a/src/main/java/com/example/documentmanagement/resolver/DocumentResolver.java
+++ b/src/main/java/com/example/documentmanagement/resolver/DocumentResolver.java
@@ -104,7 +104,13 @@ public class DocumentResolver {
                     document.setContent(content);
                     return documentService.createDocument(document, document.getOwner());
                 })
-                .doOnSuccess(doc -> log.info("Updated document: {}", doc.getTitle()));
+                .doOnSuccess(doc -> {
+                    if (doc != null) {
+                        log.info("Updated document: {}", doc.getTitle());
+                    } else {
+                        log.warn("No document found with ID: {}", id);
+                    }
+                });
     }
 
     @MutationMapping


### PR DESCRIPTION
## Summary
- avoid NPE when updateDocument returns empty by checking for null

## Testing
- `./mvnw test` *(fails: unable to download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_6845a48def6083328724eb262188018b