### PR TITLE
Add Cloud Run deployment pipeline

### DIFF
--- a/.github/workflows/cloudrun.yml
+++ b/.github/workflows/cloudrun.yml
@@ -1,0 +1,38 @@
+name: Deploy to Cloud Run
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - id: auth
+      uses: google-github-actions/auth@v1
+      with:
+        workload_identity_provider: '${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}'
+        service_account: '${{ secrets.SERVICE_ACCOUNT }}'
+
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v1
+      with:
+        project_id: '${{ secrets.GCP_PROJECT }}'
+
+    - name: Build and push image
+      run: |
+        gcloud builds submit --tag gcr.io/${{ secrets.GCP_PROJECT }}/document-management:$GITHUB_SHA
+
+    - name: Deploy to Cloud Run
+      uses: google-github-actions/deploy-cloudrun@v1
+      with:
+        service: document-management
+        image: gcr.io/${{ secrets.GCP_PROJECT }}/document-management:$GITHUB_SHA
+        region: '${{ secrets.GCP_REGION }}'
+        allow_unauthenticated: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM maven:3.9.6-eclipse-temurin-21 AS build
+WORKDIR /workspace
+COPY pom.xml .
+COPY src ./src
+RUN mvn -B package -DskipTests
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /workspace/target/document-management-0.0.1-SNAPSHOT.jar app.jar
+EXPOSE 8080
+CMD ["java","-jar","/app/app.jar"]

--- a/README.md
+++ b/README.md
@@ -396,3 +396,12 @@ The application automatically seeds data on startup:
 3. Commit your changes
 4. Push to the branch
 5. Create a Pull Request 
+## Deployment to Google Cloud Run
+
+A GitHub Actions workflow is included to build and deploy the application. Configure these repository secrets:
+- `GCP_PROJECT`: your Google Cloud project ID
+- `GCP_REGION`: target Cloud Run region
+- `WORKLOAD_IDENTITY_PROVIDER`: Workload Identity Provider name
+- `SERVICE_ACCOUNT`: service account email with Cloud Run permissions
+
+With the secrets in place, pushes to `main` automatically trigger a deployment.


### PR DESCRIPTION
## Summary
- create Dockerfile to containerize the app
- add GitHub Actions workflow to build and deploy image to Cloud Run
- document required secrets for Cloud Run deployment
- switch workflow to use workload identity federation

## Testing
- `./mvnw -q test` *(fails: wget failed to fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_6845ae03866c8332abf31c5aa8bf45e3