### PR TITLE
I've configured the Spring Boot port for Cloud Run compatibility.

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,7 +25,7 @@ spring.graphql.schema.printer.enabled=true
 # Debug Configuration
 logging.level.org.springframework.graphql=DEBUG
 logging.level.org.springframework.web=DEBUG
-server.port=9090
+server.port=${PORT:8080}
 
 # OpenFGA Configuration
 openfga.api-url=http://localhost:9080


### PR DESCRIPTION
It looks like the Cloud Run deployment was failing because the application wasn't listening on the port specified by the `PORT` environment variable (which defaults to 8080). The application was hardcoded to use port 9090.

I've updated `src/main/resources/application.properties` to set: `server.port=${PORT:8080}`

This change allows your Spring Boot application to:
- Listen on the port provided by the `PORT` environment variable when deployed on Cloud Run.
- Default to port 8080 if the `PORT` environment variable is not set (for example, when you run it locally).

The Dockerfile already correctly exposes port 8080 and uses a standard startup command, so I didn't need to make any changes there.